### PR TITLE
Precision fix

### DIFF
--- a/R/stroke.R
+++ b/R/stroke.R
@@ -226,7 +226,7 @@ interior_angle <- function(v, p1, p2) {
   norm1 <- sqrt(dx1^2 + dy1^2)
   norm2 <- sqrt(dx2^2 + dy2^2)
   cos_theta <- dot_product / (norm1 * norm2)
-  angle <- acos(cos_theta)
+  angle <- acos(round(cos_theta, 6))
   return(angle)
 }
 


### PR DESCRIPTION
I have noticed numerical errors when working on the joint rail + street network.

This is due to `cos_theta` being slightly outside the [-1;1] boundary where acos is defined. Momepy actually [implements the same rounding](https://github.com/pysal/momepy/blob/40e6d2b9611fa7fc66dd3dd3eb934d4248d8e58f/momepy/coins.py#L466) to prevent this issue.