### PR TITLE
Refactor with closures

### DIFF
--- a/R/stroke.R
+++ b/R/stroke.R
@@ -272,7 +272,7 @@ merge_lines <- function(nodes, segments, links, edge_ids,
   is_segment_used <- array(FALSE, dim = nrow(segments))
   stroke_labels <- array(integer(), dim = max(edge_ids))
   strokes <- sf::st_sfc()
-  
+
   if (is.null(from_edge)) {
     segment_ids <- seq_len(nrow(segments))
     can_reuse_segments <- FALSE
@@ -280,24 +280,23 @@ merge_lines <- function(nodes, segments, links, edge_ids,
     segment_ids <- which(edge_ids %in% from_edge)
     can_reuse_segments <- TRUE
   }
-  
-  istroke <- 1
-  
+
   traverse_segments <- function(node, link, stroke_label) {
-      stroke <- c()
-      while (TRUE) {
-          if (is.na(link) || (is_segment_used[link] && !can_reuse_segments)) break
-          stroke_labels[edge_ids[link]] <- stroke_label
-          new <- get_next(node, link, segments, links)
-          is_segment_used[link] <- TRUE
-          node <- new$node
-          link <- new$link
-          stroke <- c(node, stroke)
-      }
-      return(list(stroke = stroke, is_segment_used = is_segment_used,
-                  stroke_labels = stroke_labels))
+    stroke <- c()
+    while (TRUE) {
+      if (is.na(link) || (is_segment_used[link] && !can_reuse_segments)) break
+      stroke_labels[edge_ids[link]] <- stroke_label
+      new <- get_next(node, link, segments, links)
+      is_segment_used[link] <- TRUE
+      node <- new$node
+      link <- new$link
+      stroke <- c(node, stroke)
+    }
+    return(list(stroke = stroke, is_segment_used = is_segment_used,
+                stroke_labels = stroke_labels))
   }
-  
+
+  istroke <- 1
   for (iseg in segment_ids) {
     if (is_segment_used[iseg]) next
 

--- a/R/stroke.R
+++ b/R/stroke.R
@@ -162,17 +162,13 @@ best_link <- function(nodes, segments, links, edge_ids, flow_mode,
     start_node <- segments[iseg, "start"]
     end_node <- segments[iseg, "end"]
 
-    best_link_start <- find_best_link(start_node, end_node, iseg, segments,
-                                      links, nodes, edge_ids, flow_mode,
-                                      angle_threshold)
+    best_link_start <- find_best_link(start_node, end_node, iseg)
     if (length(best_link_start) > 0)
-      best_links[iseg, "start"] <- best_link_start
-
-    best_link_end <- find_best_link(end_node, start_node, iseg, segments,
-                                    links, nodes, edge_ids, flow_mode,
-                                    angle_threshold)
+        best_links[iseg, "start"] <- best_link_start
+    
+    best_link_end <- find_best_link(end_node, start_node, iseg)
     if (length(best_link_end) > 0)
-      best_links[iseg, "end"] <- best_link_end
+        best_links[iseg, "end"] <- best_link_end
   }
   return(best_links)
 }

--- a/R/stroke.R
+++ b/R/stroke.R
@@ -113,7 +113,7 @@ get_links <- function(segments) {
 #' @noRd
 best_link <- function(nodes, segments, links, edge_ids, flow_mode,
                       angle_threshold = 0) {
-  
+
   get_linked_segments <- function(segment_id, node_id) {
     # find the segments connected to the given one via the given node
     # 1. find all segments connected to the node
@@ -123,7 +123,7 @@ best_link <- function(nodes, segments, links, edge_ids, flow_mode,
     linked_segments <- segs[!is_current_segment]
     return(linked_segments)
   }
-  
+
   get_linked_nodes <- function(node_id, segment_id) {
     # find the node connected to the given one via the given segment(s)
     # 1. get the nodes that are part of the given segment(s)
@@ -134,17 +134,17 @@ best_link <- function(nodes, segments, links, edge_ids, flow_mode,
     is_current_node <- nds %in% node_id
     linked_nodes <- nds[!is_current_node]
     return(linked_nodes)
-  }  
-  
+  }
+
   find_best_link <- function(node, opposite_node, current_segment) {
     linked_segs <- get_linked_segments(current_segment, node)
-    
+
     get_link_on_same_edge <- function(current_segment, edge_ids) {
-        is_same_edge <- edge_ids[linked_segs] == edge_ids[current_segment]
-        link_on_same_edge <- linked_segs[is_same_edge]
-        return(link_on_same_edge)
+      is_same_edge <- edge_ids[linked_segs] == edge_ids[current_segment]
+      link_on_same_edge <- linked_segs[is_same_edge]
+      return(link_on_same_edge)
     }
-    
+
     # if in flow mode, we look for a link on the same edge
     if (flow_mode) {
       best_link <- get_link_on_same_edge(current_segment, edge_ids)
@@ -251,14 +251,14 @@ merge_lines <- function(nodes, segments, links, edge_ids,
 
   traverse_segments <- function(node, link, stroke_label) {
     get_next <- function() {
-      # find the node and segment connected to the current ones via the given link
+      # find node and segment connected to the current ones via the given link
       # 1. get the nodes and segments connected to the given link
       nodes <- segments[link, ]
       segs <- links[link, ]
       # 2. identify the position of the current node in the arrays (the current
       #    segment will be in the same position
       is_current <- nodes == node
-      # 3. exclude the current node and segment from the respective lists to find
+      # 3. exclude  current node and segment from the respective lists to find
       #    the new elements
       return(list(node = nodes[!is_current], link = segs[!is_current]))
     }
@@ -275,7 +275,7 @@ merge_lines <- function(nodes, segments, links, edge_ids,
     return(list(stroke = stroke, is_segment_used = is_segment_used,
                 stroke_labels = stroke_labels))
   }
-  
+
   to_linestring <- function(node_id) {
     points <- nodes[node_id, ]
     linestring <- sfheaders::sfc_linestring(points, x = "x", y = "y")

--- a/R/stroke.R
+++ b/R/stroke.R
@@ -164,11 +164,11 @@ best_link <- function(nodes, segments, links, edge_ids, flow_mode,
 
     best_link_start <- find_best_link(start_node, end_node, iseg)
     if (length(best_link_start) > 0)
-        best_links[iseg, "start"] <- best_link_start
-    
+      best_links[iseg, "start"] <- best_link_start
+
     best_link_end <- find_best_link(end_node, start_node, iseg)
     if (length(best_link_end) > 0)
-        best_links[iseg, "end"] <- best_link_end
+      best_links[iseg, "end"] <- best_link_end
   }
   return(best_links)
 }

--- a/R/stroke.R
+++ b/R/stroke.R
@@ -111,42 +111,48 @@ get_links <- function(segments) {
 }
 
 #' @noRd
-get_linked_segments <- function(segment_id, node_id, links) {
-  # find the segments connected to the given one via the given node
-  # 1. find all segments connected to the node
-  segs <- links[[node_id]]
-  # 2. exclude the given segment from the list
-  is_current_segment <- segs == segment_id
-  linked_segments <- segs[!is_current_segment]
-  return(linked_segments)
-}
-
-#' @noRd
-get_linked_nodes <- function(node_id, segment_id, segments) {
-  # find the node connected to the given one via the given segment(s)
-  # 1. get the nodes that are part of the given segment(s)
-  nds <- segments[segment_id, ]
-  # 2. flatten the array row by row (i.e. along the node dimension)
-  nds <- as.vector(t(nds))
-  # 3. exclude the given node from the list
-  is_current_node <- nds %in% node_id
-  linked_nodes <- nds[!is_current_node]
-  return(linked_nodes)
-}
-
-#' @noRd
 best_link <- function(nodes, segments, links, edge_ids, flow_mode,
                       angle_threshold = 0) {
+  
+  get_linked_segments <- function(segment_id, node_id) {
+    # find the segments connected to the given one via the given node
+    # 1. find all segments connected to the node
+    segs <- links[[node_id]]
+    # 2. exclude the given segment from the list
+    is_current_segment <- segs == segment_id
+    linked_segments <- segs[!is_current_segment]
+    return(linked_segments)
+  }
+  
+  get_linked_nodes <- function(node_id, segment_id) {
+    # find the node connected to the given one via the given segment(s)
+    # 1. get the nodes that are part of the given segment(s)
+    nds <- segments[segment_id, ]
+    # 2. flatten the array row by row (i.e. along the node dimension)
+    nds <- as.vector(t(nds))
+    # 3. exclude the given node from the list
+    is_current_node <- nds %in% node_id
+    linked_nodes <- nds[!is_current_node]
+    return(linked_nodes)
+  }  
+  
   find_best_link <- function(node, opposite_node, current_segment) {
-    linked_segs <- get_linked_segments(current_segment, node, links)
+    linked_segs <- get_linked_segments(current_segment, node)
+    
+    get_link_on_same_edge <- function(current_segment, edge_ids) {
+        is_same_edge <- edge_ids[linked_segs] == edge_ids[current_segment]
+        link_on_same_edge <- linked_segs[is_same_edge]
+        return(link_on_same_edge)
+    }
+    
     # if in flow mode, we look for a link on the same edge
     if (flow_mode) {
-      best_link <- get_link_on_same_edge(linked_segs, current_segment, edge_ids)
+      best_link <- get_link_on_same_edge(current_segment, edge_ids)
     }
     # if not in flow mode or if no link is found on the same edge, we look for
     # the best link by calculating the interior angles with all connections
     if (length(best_link) == 0 || !flow_mode) {
-      linked_nodes <- get_linked_nodes(node, linked_segs, segments)
+      linked_nodes <- get_linked_nodes(node, linked_segs)
       angles <- interior_angle(nodes[node, ],
                                nodes[opposite_node, , drop = FALSE],
                                nodes[linked_nodes, , drop = FALSE])
@@ -171,13 +177,6 @@ best_link <- function(nodes, segments, links, edge_ids, flow_mode,
       best_links[iseg, "end"] <- best_link_end
   }
   return(best_links)
-}
-
-#' @noRd
-get_link_on_same_edge <- function(links, current_segment, edge_ids) {
-  is_same_edge <- edge_ids[links] == edge_ids[current_segment]
-  link_on_same_edge <- links[is_same_edge]
-  return(link_on_same_edge)
 }
 
 #' @noRd
@@ -236,27 +235,6 @@ cross_check_links <- function(best_links) {
   return(links)
 }
 
-#' @noRd
-get_next <- function(node, link, segments, links) {
-  # find the node and segment connected to the current ones via the given link
-  # 1. get the nodes and segments connected to the given link
-  nodes <- segments[link, ]
-  segs <- links[link, ]
-  # 2. identify the position of the current node in the arrays (the current
-  #    segment will be in the same position
-  is_current <- nodes == node
-  # 3. exclude the current node and segment from the respective lists to find
-  #    the new elements
-  return(list(node = nodes[!is_current], link = segs[!is_current]))
-}
-
-#' @noRd
-to_linestring <- function(node_id, nodes) {
-  points <- nodes[node_id, ]
-  linestring <- sfheaders::sfc_linestring(points, x = "x", y = "y")
-  return(linestring)
-}
-
 merge_lines <- function(nodes, segments, links, edge_ids,
                         from_edge = NULL, attributes = FALSE, crs = NULL) {
   is_segment_used <- array(FALSE, dim = nrow(segments))
@@ -272,11 +250,23 @@ merge_lines <- function(nodes, segments, links, edge_ids,
   }
 
   traverse_segments <- function(node, link, stroke_label) {
+    get_next <- function() {
+      # find the node and segment connected to the current ones via the given link
+      # 1. get the nodes and segments connected to the given link
+      nodes <- segments[link, ]
+      segs <- links[link, ]
+      # 2. identify the position of the current node in the arrays (the current
+      #    segment will be in the same position
+      is_current <- nodes == node
+      # 3. exclude the current node and segment from the respective lists to find
+      #    the new elements
+      return(list(node = nodes[!is_current], link = segs[!is_current]))
+    }
     stroke <- c()
     while (TRUE) {
       if (is.na(link) || (is_segment_used[link] && !can_reuse_segments)) break
       stroke_labels[edge_ids[link]] <- stroke_label
-      new <- get_next(node, link, segments, links)
+      new <- get_next()
       is_segment_used[link] <- TRUE
       node <- new$node
       link <- new$link
@@ -284,6 +274,12 @@ merge_lines <- function(nodes, segments, links, edge_ids,
     }
     return(list(stroke = stroke, is_segment_used = is_segment_used,
                 stroke_labels = stroke_labels))
+  }
+  
+  to_linestring <- function(node_id) {
+    points <- nodes[node_id, ]
+    linestring <- sfheaders::sfc_linestring(points, x = "x", y = "y")
+    return(linestring)
   }
 
   istroke <- 1
@@ -312,7 +308,7 @@ merge_lines <- function(nodes, segments, links, edge_ids,
 
     # combine strokes and add to results
     stroke <- c(forward_stroke, stroke, backward_stroke)
-    strokes <- c(strokes, to_linestring(stroke, nodes))
+    strokes <- c(strokes, to_linestring(stroke))
     istroke <- istroke + 1
   }
 


### PR DESCRIPTION
I moved `traverese_links()` and `find_best_link()` into `merge_lines()` and `best_link()` resepectively. The advantage is that indeed we can pass around arguments implictly and thus the signatures of the encapsulated functions are simpler.

I am sharing a few things that became clearer to me while I was addressing this issue:

- Now I have a better view on how closures are used in R. In fact, all functions in R are closures as they ecnlose their environment (hence my slight confusion as I thought they are somehow more complicated). I mistakenly thought that functional programming in R means using pure functions, which would not allow for a function to interact with its enclosing environment as we do here. The general (more pragmatic) recommendation is a functional style of programming rather then sticking to pure functions, which we do not violate.

- One thing we do not use here and is easily done is to assign values to variables in the enclosing environment with `<<-`. Our closures, only _use_ variables from the enclosing environment (the ones that are now implicitly passed down to the nested functions), but there may be situations in which we want to create or change a variable in the enclosing environment with `<<-`.