### PR TITLE
Do not skip edges where a stroke has already passed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix rendering of package information on the pkgdown website
 - Small fixes to docstrings
+- When an initial set of edges is provided, we do not skip through segments that we have already considered in other strokes
 
 # Version 0.1.0 - 2024-12-16
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,20 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- DOI is added to CITATION.cff and README (badge)
-- Contributing guidelines are added to the package
-- Added gitHub action to compare stroke to momepy on pull request
-- A test on real (packaged) data is included
+- DOI is added to CITATION.cff and README (badge) [#43](https://github.com/CityRiverSpaces/rcoins/pull/43)
+- Contributing guidelines are added to the package [#44](https://github.com/CityRiverSpaces/rcoins/pull/44)
+- Added gitHub action to compare stroke to momepy on pull request [#47](https://github.com/CityRiverSpaces/rcoins/pull/47)
+- A test on real (packaged) data is included [#46](https://github.com/CityRiverSpaces/rcoins/pull/46)
 
 ## Changed
 
-- Data resized to city boundary (buffer is dropped)
+- Data resized to city boundary (buffer is dropped) [#46](https://github.com/CityRiverSpaces/rcoins/pull/46)
 
 ## Fixed
 
-- Fix rendering of package information on the pkgdown website
-- Small fixes to docstrings
-- When an initial set of edges is provided, we do not skip through segments that we have already considered in other strokes
+- Fix rendering of package information on the pkgdown website [#42](https://github.com/CityRiverSpaces/rcoins/pull/42)
+- Small fixes to docstrings [#45](https://github.com/CityRiverSpaces/rcoins/pull/45)
+- When an initial set of edges is provided, we do not skip  through segments that we have already considered in other strokes [#48](https://github.com/CityRiverSpaces/rcoins/pull/48)
 
 # Version 0.1.0 - 2024-12-16
 

--- a/R/stroke.R
+++ b/R/stroke.R
@@ -256,7 +256,7 @@ merge_lines <- function(nodes, segments, links, edge_ids,
 
   istroke <- 1
   for (iseg in segment_ids) {
-    if (is_segment_used[iseg]) next
+    if (is_segment_used[iseg] && !can_reuse_segments) next
 
     stroke <- c(iseg)
 


### PR DESCRIPTION
When we specify the initial edges, we should construct strokes starting from *all* edges provided, regardless on whether we have already found a stroke that go through it. 

Since we are connecting line segments following the "best-link" option, I naively thought that if we already passed through a segment we could skip this in the following iterations because we would always end up building the same stroke. This is not always the case, see example here: 

![Screenshot 2025-03-28 at 15 01 41](https://github.com/user-attachments/assets/6f3b778f-f9c7-49b8-8309-9735ea86a5a9)

The stroke built from the yellow crossing (red line) goes through the green crossing as well. However, building the stroke starting from the green crossing leads to the blue line instead. The reason why this happen is that at 3-way crossings A being the best link of B does not imply that B is the best link of A. 

This PR fixes this issue by neglecting the skip-iteration statement when a set of initial edges is provided.  
